### PR TITLE
Fix QuickPromise installation warning

### DIFF
--- a/qffuture.cpp
+++ b/qffuture.cpp
@@ -197,7 +197,7 @@ QJSValue Future::promise(QJSValue future)
     args << future;
 
     QJSValue result = create.call(args);
-    if (result.isError()) {
+    if (result.isError() || result.isUndefined()) {
         qWarning() << "Future.promise: QuickPromise is not installed or setup properly";
         result = QJSValue();
     }


### PR DESCRIPTION
When used in Qt 5.9 (haven't tried in any other versions),
promiseCreator.create returns undefined value instead of error
and brings additional console warning:
"QQmlComponent: Component is not ready"

This patch helps debug the problem when quickfuture is installed
manually instead of using qpm.