### PR TITLE
Fix non-void canceled QFuture crash

### DIFF
--- a/qfvariantwrapper.h
+++ b/qfvariantwrapper.h
@@ -16,7 +16,9 @@ namespace QuickFuture {
 
     template <typename T>
     inline QJSValueList valueList(const QPointer<QQmlEngine>& engine, const QFuture<T>& future) {
-        QJSValue value = engine->toScriptValue<T>(future.result());
+        QJSValue value;
+        if (future.resultCount() > 0)
+            value = engine->toScriptValue<T>(future.result());
         return QJSValueList() << value;
     }
 

--- a/tests/quickfutureunittests/actor.cpp
+++ b/tests/quickfutureunittests/actor.cpp
@@ -62,6 +62,15 @@ QFuture<void> Actor::canceled()
     return defer.future();
 }
 
+QFuture<int> Actor::canceledInt()
+{
+    auto defer = deferred<int>();
+
+    defer.cancel();
+
+    return defer.future();
+}
+
 QFuture<bool> Actor::delayReturnBool(bool value)
 {
     auto defer = deferred<bool>();

--- a/tests/quickfutureunittests/actor.h
+++ b/tests/quickfutureunittests/actor.h
@@ -31,6 +31,8 @@ public slots:
 
     QFuture<void> canceled();
 
+    QFuture<int> canceledInt();
+
     QFuture<bool> delayReturnBool(bool value);
 
     QFuture<QSize> delayReturnQSize(QSize value);

--- a/tests/quickfutureunittests/qmltests/tst_Callback.qml
+++ b/tests/quickfutureunittests/qmltests/tst_Callback.qml
@@ -74,6 +74,25 @@ CustomTestCase {
         compare(called, true);
     }
 
+    function test_onCanceledInt() {
+        var future = Actor.canceledInt();
+        var called = false;
+
+        compare(Future.isFinished(future), true);
+        compare(Future.isRunning(future), false);
+        compare(Future.isCanceled(future), true);
+
+        Future.onCanceled(future, function() {
+            called = true;
+        });
+
+        waitUntil(function() {
+            return called;
+        }, 1000);
+
+        compare(called, true);
+    }
+
     function test_result() {
         var future, result;
         future = Actor.delayReturnBool(true);


### PR DESCRIPTION
Added a test reproducing application crash when trying to access canceled non-void canceled QFuture and fixed a crash.