### PR TITLE
Fix #9 moc warning: quickfuture.h:0: Note: No relevant classes found.…

### DIFF
--- a/src/src.pri
+++ b/src/src.pri
@@ -6,4 +6,4 @@ HEADERS += \
     $$PWD/qfvariantwrapper.h \
     $$PWD/qffuture.h \
     $$PWD/QuickFuture \
-    $$PWD/quickfuture.h
+    #


### PR DESCRIPTION
… No output generated.